### PR TITLE
Clean up factory on unmount

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,3 +25,7 @@ Internal testing version
 
 - New branding
 - **Breaking change**: the `uiTheme` config option is removed.
+
+## 6.0.3
+
+- Close Connect on unmount

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arcadia-eng/connect-react",
-  "version": "6.0.2",
+  "version": "6.0.3",
   "description": "React package for implementing Arc Connect",
   "main": "dist/index.js",
   "scripts": {

--- a/src/use-connect.js
+++ b/src/use-connect.js
@@ -73,6 +73,10 @@ export const useConnect = () => {
     if (scriptError) setUtilityConnectError(scriptLoadError);
   }, [scriptError]);
 
+  useEffect(() => {
+    return () => factory?.close();
+  }, [factory]);
+
   const open = useCallback(
     async config => {
       if (!factory) {

--- a/test/test-utils.js
+++ b/test/test-utils.js
@@ -8,6 +8,7 @@ export const generateUseScriptMock = ({
   validationErrors = false,
 } = {}) => {
   const mockConnect = {
+    close: jest.fn(),
     create: jest.fn().mockResolvedValue(),
     validate: jest.fn().mockResolvedValue(),
   };

--- a/test/use-connect.test.js
+++ b/test/use-connect.test.js
@@ -132,5 +132,21 @@ describe('useConnect', () => {
       });
       expect(sampleConfig.callbacks.onClose).toHaveBeenCalled();
     });
+
+    describe('on unmount', () => {
+      it('does not have any issue closing when the factory is not loaded', () => {
+        useScript.mockImplementation(generateUseScriptMock({ longLoad: true }));
+        const { unmount } = renderHook(() => useConnect());
+        unmount();
+      });
+
+      it('can close the factory when the factory is loaded', async () => {
+        const { result, unmount, waitFor } = renderHook(() => useConnect());
+        await waitFor(() => expect(result.current[0].loading).toEqual(false));
+        expect(window._ArcConnect.close).toHaveBeenCalledTimes(0);
+        unmount();
+        expect(window._ArcConnect.close).toHaveBeenCalledTimes(1);
+      });
+    });
   });
 });

--- a/test/with-connect.test.js
+++ b/test/with-connect.test.js
@@ -141,5 +141,25 @@ describe('withConnect', () => {
       });
       expect(mockConfig.callbacks.onClose).toHaveBeenCalled();
     });
+
+    describe('on unmount', () => {
+      it('does not have any issue closing when the factory is not loaded', () => {
+        useScript.mockImplementation(generateUseScriptMock({ longLoad: true }));
+        const { unmount } = render(
+          <MockCredentialComponentWithHOC {...props} />
+        );
+        unmount();
+      });
+
+      it('can close the factory when the factory is loaded', async () => {
+        const { unmount } = render(
+          <MockCredentialComponentWithHOC {...props} />
+        );
+        await clickOpen();
+        expect(window._ArcConnect.close).toHaveBeenCalledTimes(0);
+        unmount();
+        expect(window._ArcConnect.close).toHaveBeenCalledTimes(1);
+      });
+    });
   });
 });


### PR DESCRIPTION
## What
Closes the factory on unmount so the modal does not persist if it the the user navigates away from an opened modal within an app.

https://arcadiapower.atlassian.net/browse/EMBARC-77

## How to test
- Build this library and place it in the node modules of a project that uses it
- Try to recreate the bug, it should no longer work.