### PR TITLE
Update peer dependencies to include react 18 and update react-script-hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
-## 7.0.0
+## 7.1.0
+
+- Updates react-script-hook to 1.7.2
+- Expands peer dependencies to include react 18
+
+# 7.0.0
 
 - Fixes major issue with Connect source url
 - **Breaking change**: All prior versions will be marked as deprecated
@@ -13,28 +18,27 @@
 
 - Close Connect on unmount
 
-## 6.0.0
+# 6.0.0
 
 - New branding
 - **Breaking change**: the `uiTheme` config option is removed.
 
-## 5.0.0
+# 5.0.0
 
 - Renamed the package from `utility-connect-react` to `connect-react`. Please reinstall from npm `npm i @arcadia-eng/connect-react`
   - `useUtilityConnect` hook renamed to `useConnect`
   - `withUtilityConnect` HoC renamed to `withConnect`
   - `config.UtilityConnectToken` renamed to `config.ConnectToken`
 
-## 4.0.0
+# 4.0.0
 
 - **Breaking change**: New callback and config format
 
-## 3.0.0
+# 3.0.0
 
 - Errors in `use-utility-connect` now return a consistent `Error` object
 - `with-utility-connect` now matches the current implementation of `use-utility-connect`
   - **Breaking Change**: The `ready` prop is no longer passed down by the HOC. Please use `loading` instead.
-
 
 ### 0.0.1
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -7075,9 +7075,9 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "react-script-hook": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/react-script-hook/-/react-script-hook-1.2.1.tgz",
-      "integrity": "sha512-IRqtZcXjFYWf7HnC3zj/n46D3QP5XhrVeGj0t2JbHY2ws73zvs6tOHWVr5l2GShRGqZEBCFlguYfVUU2lI2qzw=="
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/react-script-hook/-/react-script-hook-1.7.2.tgz",
+      "integrity": "sha512-fhyCEfXb94fag34UPRF0zry1XGwmVY+79iibWwTqAoOiCzYJQOYTiWJ7CnqglA9tMSV8g45cQpHCMcBwr7dwhA=="
     },
     "react-test-renderer": {
       "version": "16.14.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arcadia-eng/connect-react",
-  "version": "7.0.0",
+  "version": "7.1.0",
   "description": "React package for implementing Arc Connect",
   "main": "dist/index.js",
   "scripts": {
@@ -57,12 +57,12 @@
     "webpack-cli": "^4.3.1"
   },
   "peerDependencies": {
-    "react": "^16.14.0 || ^17.0.0",
-    "react-dom": "^16.14.0 || ^17.0.0"
+    "react": "^16.14.0 || 17 - 18",
+    "react-dom": "^16.14.0 || 17 - 18"
   },
   "dependencies": {
     "prop-types": "^15.7.2",
-    "react-script-hook": "^1.2.1"
+    "react-script-hook": "^1.7.2"
   },
   "jest": {
     "coveragePathIgnorePatterns": [


### PR DESCRIPTION
### What

Updates peer dependencies to include react-18 and update the react-hook-script dependency 

### How to test

If you `npm i @arcadia-eng/connect-react@next` in an application you should get the latest version.

I tested this in a react 17 application (platform dashboard) and react 18 (connect 2.0) - and both were able to load the script as expected.