### PR TITLE
SRE-260 GitHub actions replace codeship

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,8 @@ on: [push]
 jobs:
   run-ci:
     runs-on: ubuntu-latest
+    environment:
+      name: dev
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ jobs:
     environment:
       name: dev
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,16 @@
+name: Run RSpec tests
+on: [push]
+jobs:
+  run-rspec-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-node@v3
+        node-version-file: '.nvmrc'
+
+      - name: setup
+        run: bin/ci/setup.sh
+
+      - name: test
+        run: bin/ci/test.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,3 +17,5 @@ jobs:
 
       - name: test
         run: bin/ci/test.sh
+        env:
+          CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
-name: Run RSpec tests
+name: Run CI
 on: [push]
 jobs:
-  run-rspec-tests:
+  run-ci:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,8 @@ jobs:
       - uses: actions/checkout@v2
 
       - uses: actions/setup-node@v3
-        node-version-file: '.nvmrc'
+        with:
+          node-version-file: '.nvmrc'
 
       - name: setup
         run: bin/ci/setup.sh

--- a/bin/ci/test.sh
+++ b/bin/ci/test.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
-curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > "${HOME}/bin/cc-test-reporter" && chmod +x "${HOME}/bin/cc-test-reporter"
+dir=${GITHUB_WORKSPACE:-${HOME}}
+echo $dir
+curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > "${dir}/bin/cc-test-reporter" && chmod +x "${dir}/bin/cc-test-reporter"
 
 set -euo pipefail
 IFS=$'\n\t'

--- a/bin/ci/test.sh
+++ b/bin/ci/test.sh
@@ -7,7 +7,7 @@ set -euo pipefail
 IFS=$'\n\t'
 
 npm run lint
-cc-test-reporter before-build
+${dir}/bin/cc-test-reporter before-build
 npm run test:coverage
 
-cc-test-reporter after-build --exit-code $? --prefix /home/rof/src/github.com/ArcadiaPower/utility-connect-react
+${dir}/bin/cc-test-reporter after-build --exit-code $? --prefix /home/rof/src/github.com/ArcadiaPower/utility-connect-react


### PR DESCRIPTION
SRE-260 GitHub actions replace codeship

I had to make some adjustments to test.sh script to adapt it to run in both local and github action runners with regards to pathing of `$HOME`. 

after this is merged, we should be able to disable the codeship integration

run on actions
![Screenshot 2023-10-24 at 2 52 13 PM](https://github.com/ArcadiaPower/connect-react/assets/5286873/96536152-7605-45eb-9a25-89b77e190bc4)
